### PR TITLE
feat: make frontend API URL configurable

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:8000

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -21,6 +21,25 @@ This is the React frontend for the ElderDocs document management system.
    npm install
    ```
 
+### Environment Variables
+
+Create a `.env` file in this directory to configure the API endpoint:
+
+```
+REACT_APP_API_URL=http://localhost:8000
+```
+
+During development, the app loads this value automatically. If the variable is
+absent, it falls back to `http://localhost:8000`.
+
+For production or other environments, set `REACT_APP_API_URL` before running a
+build. Example scripts are provided:
+
+```
+npm run build:staging
+npm run build:prod
+```
+
 ### Running the Application
 
 1. Start the development server:
@@ -34,7 +53,7 @@ This is the React frontend for the ElderDocs document management system.
 
 To create a production build:
 ```
-npm run build
+npm run build:prod
 ```
 
 ## Project Structure
@@ -57,7 +76,7 @@ frontend/
 
 - View citizen records in a table format
 - Upload PDF documents containing citizen information
-- Communicates with the backend API at `http://localhost:8000`
+- Communicates with the backend API specified by `REACT_APP_API_URL`
 
 ## API Endpoints
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "build:staging": "REACT_APP_API_URL=https://staging.example.com react-scripts build",
+    "build:prod": "REACT_APP_API_URL=https://api.example.com react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "dev": "react-scripts start"

--- a/frontend/src/services/ApiService.js
+++ b/frontend/src/services/ApiService.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 // Create axios instance with default config
 const apiClient = axios.create({
-  baseURL: 'http://localhost:8000', // Default backend URL
+  baseURL: process.env.REACT_APP_API_URL || 'http://localhost:8000', // Backend URL from environment
   timeout: 30000,
   headers: {
     'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- load API base URL from `REACT_APP_API_URL` with fallback
- document `REACT_APP_API_URL` usage and add example env file
- add environment-specific build scripts

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module '@testing-library/jest-dom')*
- `npm install --save-dev @testing-library/jest-dom` *(fails: 403 Forbidden)*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c8b4a4a8c8333a9bb955c00864256